### PR TITLE
Add 'Scale media (up) to fit' option

### DIFF
--- a/src/app/app-settings/app-settings.component.html
+++ b/src/app/app-settings/app-settings.component.html
@@ -26,6 +26,7 @@
     <mat-slide-toggle color="primary" formControlName="mediaLoop" class="margin-bottom-16">Loop video and audio files</mat-slide-toggle>
     <mat-slide-toggle color="primary" formControlName="mediaDefaultMuted" class="margin-bottom-16">Video and audio files start muted</mat-slide-toggle>
     <mat-slide-toggle color="primary" formControlName="sendViews" class="margin-bottom-16">Submit views and view durations to Hydrus</mat-slide-toggle>
+    <mat-slide-toggle color="primary" formControlName="scaleMediaToFit" class="margin-bottom-16">Scale media (up) to fit</mat-slide-toggle>
     <h2 class="mat-headline-6">Send</h2>
     <mat-form-field appearance="outline">
       <mat-label>Default page name for sending URLs</mat-label>

--- a/src/app/photoswipe.service.ts
+++ b/src/app/photoswipe.service.ts
@@ -72,10 +72,10 @@ export class PhotoswipeService {
       maxZoomLevel: 10,
       initialZoomLevel: (zoomLevelObject) => {
         if(!this.settingsService.appSettings.scaleMediaToFit) {
-          return zoomLevelObject.fit;
+          return zoomLevelObject.fit; // the default behavior (which doesn't scale up)
         }
-        const wscale = window.innerWidth / zoomLevelObject.itemData.width;
-        const hscale = window.innerHeight / zoomLevelObject.itemData.height;
+        const wscale = zoomLevelObject.panAreaSize.x / zoomLevelObject.itemData.width;
+        const hscale = zoomLevelObject.panAreaSize.y / zoomLevelObject.itemData.height;
         return wscale < hscale ? wscale : hscale;
       },
       //tapAction: null,

--- a/src/app/photoswipe.service.ts
+++ b/src/app/photoswipe.service.ts
@@ -69,7 +69,15 @@ export class PhotoswipeService {
       zoom: false,
       close: false,
       //secondaryZoomLevel: 1,
-      maxZoomLevel: 2,
+      maxZoomLevel: 10,
+      initialZoomLevel: (zoomLevelObject) => {
+        if(!this.settingsService.appSettings.scaleMediaToFit) {
+          return zoomLevelObject.fit;
+        }
+        const wscale = window.innerWidth / zoomLevelObject.itemData.width;
+        const hscale = window.innerHeight / zoomLevelObject.itemData.height;
+        return wscale < hscale ? wscale : hscale;
+      },
       //tapAction: null,
       errorMsg: 'The file cannot be loaded',
       trapFocus: false

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -23,6 +23,7 @@ export interface AppSettingsV1 {
   themeColor: string;
   themeVariant: SettingsThemeVariant;
   sendViews: boolean;
+  scaleMediaToFit: boolean;
 }
 
 export type AppSettingsStorage = AppSettingsV1;
@@ -49,4 +50,5 @@ export const defaultAppSettings: AppSettings = {
   themeColor: '#3f51b5',
   themeVariant: SettingsThemeVariant.DEFAULT,
   sendViews: true,
+  scaleMediaToFit: false,
 }


### PR DESCRIPTION
A must have in the year 2025.

Open to bikeshedding the option name and maintainer edits on the pr

EDIT: I can't tell if it matters whether elementSize.x&elementSize.y are used over itemData.width&itemData.height. Changing browser page zoom doesn't seem to change anything.