### PR TITLE
Make the scrollwheel work on the page tab list

### DIFF
--- a/src/app/pages/pages.component.html
+++ b/src/app/pages/pages.component.html
@@ -1,7 +1,7 @@
 <div>
   <ng-template #recursiveList let-list>
 
-    <mat-tab-group animationDuration="0ms" dynamicHeight class="pages-tab-group">
+    <mat-tab-group animationDuration="0ms" dynamicHeight class="pages-tab-group" (wheel)="scrollTabs($event)" #tabGroup>
       @for (page of list; track page.page_key) {
         <mat-tab>
           <ng-template mat-tab-label>

--- a/src/app/pages/pages.component.ts
+++ b/src/app/pages/pages.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { HydrusPagesService } from '../hydrus-pages.service';
 import { HydrusPageListItem, HydrusPageType } from '../hydrus-page';
 
@@ -21,6 +21,29 @@ export class PagesComponent implements OnInit {
         this.pages = result;
       }
     );
+  }
+
+  // scrollTabs sourced & edited from https://stackoverflow.com/questions/51544452/making-material-tabs-scrollable/51545130#51545130 by Kim Kern  CC BY-SA 4.0
+  @ViewChild("tabGroup")
+  tabGroup;
+  scrollTabs(event: WheelEvent) {
+    if ((event.target as HTMLElement).closest(".mat-mdc-tab-body-wrapper")) {
+      // we scrolled on the thumbnails
+      return;
+    }
+    // angular updates could demolish this whenever but it has been working for a while so 😇
+    const children = this.tabGroup._tabHeader._elementRef.nativeElement.children;
+    const back = children[0];
+    const forward = children[2];
+    if (event.deltaY > 0) {
+      forward.click();
+    } else {
+      back.click();
+    }
+
+    // block propogation so we don't get down-scrolls on the right-end of the tab list
+    event.preventDefault();
+    return false;
   }
 
 }


### PR DESCRIPTION
Another must have in the year 2025.

Could be a bit nicer (like not having the animation) but angular wants developers to die if they stray outside the intended path.

Basically a copy of [this stackoverflow answer](https://stackoverflow.com/questions/51544452/making-material-tabs-scrollable/51545130#51545130) with an edit to block propogation & a shitty check to see if the scroll was on thumbnails (to ignore).

(Open to bikeshedding and maintainer edits on the pr)